### PR TITLE
Jk/issue4

### DIFF
--- a/src/sds_data_model/_vector.py
+++ b/src/sds_data_model/_vector.py
@@ -146,9 +146,10 @@ def _from_delayed_to_data_array(
     delayed_arrays: Tuple[Delayed],
     name: str,
     metadata: Metadata,
+    dtype: str,
 ) -> DataArray:
     dask_arrays = tuple(
-        from_delayed(mask, dtype="uint8", shape=OUT_SHAPE) for mask in delayed_arrays
+        from_delayed(mask, dtype=dtype, shape=OUT_SHAPE) for mask in delayed_arrays
     )
     rows = chunked(dask_arrays, 7)
     data = block(list(rows))

--- a/src/sds_data_model/_vector.py
+++ b/src/sds_data_model/_vector.py
@@ -34,6 +34,7 @@ def _from_file(
     bbox: BoundingBox,
     **kwargs,
 ) -> Delayed:
+    """Returns a delayed GeoDataFrame clipped to a given bounding box."""
     return read_file(
         filename=data_path,
         bbox=box(*bbox),
@@ -43,11 +44,13 @@ def _from_file(
 
 @delayed
 def _select(gpdf: Delayed, columns: List[str]) -> Delayed:
+    """Returns given columns from a delayed GeoDataFrame."""
     return gpdf[columns]
 
 
 @delayed
 def _where(gpdf: Delayed, condition: Series) -> Delayed:
+    """Returns a delayed GeoDataFrame filtered by a given condition."""
     return gpdf[condition]
 
 
@@ -59,6 +62,7 @@ def _join(
     fillna: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> Delayed:
+    """Returns a delayed GeoDataFrame joined to a given DataFrame."""
     _gpdf = merge(
         left=gpdf,
         right=other,
@@ -79,6 +83,7 @@ def _get_mask(
     dtype: str,
     transform: Affine,
 ) -> Delayed:
+    """Returns a delayed boolean Numpy ndarray where 1 means the pixel overlaps a geometry."""
     if all(gpdf.geometry.is_empty) and invert:
         return zeros(
             shape=out_shape,
@@ -102,6 +107,7 @@ def _get_shapes(
     gpdf: GeoDataFrame,
     column: str,
 ) -> Generator[Tuple[BaseGeometry, Any], None, None]:
+    """Yields (Geometry, value) tuples for every row in a GeoDataFrame."""
     return (
         (geometry, value)
         for geometry, value in zip(gpdf["geometry"], gpdf[column])
@@ -124,6 +130,7 @@ def _to_raster(
     transform: Affine,
     **kwargs,
 ) -> Delayed:
+    """Returns a delayed boolean Numpy ndarray with values taken from a given column."""
     if all(gpdf.geometry.is_empty):
         return zeros(
             shape=out_shape,
@@ -149,6 +156,7 @@ def _from_delayed_to_data_array(
     metadata: Metadata,
     dtype: str,
 ) -> DataArray:
+    """Converts a 1D delayed Numpy array into a 2D DataArray."""
     dask_arrays = tuple(
         from_delayed(mask, dtype=dtype, shape=OUT_SHAPE) for mask in delayed_arrays
     )

--- a/src/sds_data_model/_vector.py
+++ b/src/sds_data_model/_vector.py
@@ -11,6 +11,7 @@ from more_itertools import chunked
 from numpy import arange, ones, zeros
 from pandas import DataFrame, Series, merge
 from rasterio.features import geometry_mask, rasterize
+from rasterio.dtypes import get_minimum_dtype
 from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 from xarray import DataArray
@@ -105,6 +106,12 @@ def _get_shapes(
         (geometry, value)
         for geometry, value in zip(gpdf["geometry"], gpdf[categorical_column])
     )
+
+def _get_col_dtype(
+    gpdf: GeoDataFrame,
+    categorical_column: str,
+) -> str:
+    return get_minimum_dtype(gpdf[categorical_column])
 
 
 @delayed

--- a/src/sds_data_model/_vector.py
+++ b/src/sds_data_model/_vector.py
@@ -100,24 +100,25 @@ def _get_mask(
 
 def _get_shapes(
     gpdf: GeoDataFrame,
-    categorical_column: str,
+    column: str,
 ) -> Generator[Tuple[BaseGeometry, Any], None, None]:
     return (
         (geometry, value)
-        for geometry, value in zip(gpdf["geometry"], gpdf[categorical_column])
+        for geometry, value in zip(gpdf["geometry"], gpdf[column])
     )
 
 def _get_col_dtype(
     gpdf: GeoDataFrame,
-    categorical_column: str,
+    column: str,
 ) -> str:
-    return get_minimum_dtype(gpdf[categorical_column])
+    """This method takes a vectortile and returns the minimum rasterio data type required to represent the data in the column of interest."""
+    return get_minimum_dtype(gpdf[column])
 
 
 @delayed
-def _to_categorical_raster(
+def _to_raster(
     gpdf: GeoDataFrame,
-    categorical_column: str,
+    column: str,
     out_shape: Tuple[int, int],
     dtype: str,
     transform: Affine,
@@ -131,7 +132,7 @@ def _to_categorical_raster(
     else:
         shapes = _get_shapes(
             gpdf=gpdf,
-            categorical_column=categorical_column,
+            column=column,
         )
         return rasterize(
             shapes=shapes,

--- a/src/sds_data_model/constants.py
+++ b/src/sds_data_model/constants.py
@@ -20,7 +20,9 @@ CHARACTER_STRING = GCO + "CharacterString"
 
 BoundingBox = Tuple[int, int, int, int]
 
-raster_dtype_levels = ['int8', 'uint8', 'uint16', 'int16', 'uint32', 'int32', 'float32', 'float64']
+# Order for data types taken from rasterio docs lines 14-27 
+# https://github.com/rasterio/rasterio/blob/master/rasterio/dtypes.py
+raster_dtype_levels = ['bool', 'uint8', 'int8', 'uint16', 'int16', 'uint32', 'int32', 'float32', 'float64', 'complex', 'complex64', 'complex128']
 
 def _get_bboxes(
     xmin: int = BNG_XMIN,

--- a/src/sds_data_model/constants.py
+++ b/src/sds_data_model/constants.py
@@ -1,23 +1,34 @@
 from itertools import product
 from typing import Tuple
 
-BNG = "OSGB 1936 / British National Grid"
+# British National Grid (BNG) name strings
+BNG = ("OSGB 1936 / British National Grid", "OSGB36 / British National Grid")
+# Minimum x value of BNG in meters
 BNG_XMIN = 0
+# Minimum y value of BNG in meters
 BNG_YMIN = 0
+# Maximum x value of BNG in meters
 BNG_XMAX = 700_000
+# Maximum y value of BNG in meters
 BNG_YMAX = 1_300_000
+# Height and width of bounding box in meters 
 BOX_SIZE = 100_000
+# Height and width of raster cell in meters 
 CELL_SIZE = 10
+# Height and width of VectorTile in cells 
 TILE_SIZE = BOX_SIZE // CELL_SIZE
+# Dimensions of VectorTile in cells 
 OUT_SHAPE = (TILE_SIZE, TILE_SIZE)
 
-
+#! Ignore for now, these are XML namespaces used in Gemini Metadata
 GMD = "{http://www.isotc211.org/2005/gmd}"
 GML = "{http://www.opengis.net/gml/3.2}"
 GMX = "{http://www.isotc211.org/2005/gmx}"
 GCO = "{http://www.isotc211.org/2005/gco}"
 CHARACTER_STRING = GCO + "CharacterString"
 
+# Type alias, i.e. a BoundingBox is a Tuple of 4 integers
+# See https://docs.python.org/3.8/library/typing.html#type-aliases
 BoundingBox = Tuple[int, int, int, int]
 
 # Order for data types taken from rasterio docs lines 14-27 
@@ -31,6 +42,7 @@ def _get_bboxes(
     ymax: int = BNG_YMAX,
     box_size: int = BOX_SIZE,
 ) -> Tuple[BoundingBox, ...]:
+    """Returns a tuple of BoundingBox for BNG 100km grid squares.""" 
     eastings = range(xmin, xmax, box_size)
     northings = range(ymax, ymin, -box_size)
 
@@ -38,5 +50,5 @@ def _get_bboxes(
 
     return tuple((x, y - box_size, x + box_size, y) for y, x in top_left_coordinates)
 
-
+# A tuple of BoundingBox for BNG 100km grid squares.
 BBOXES = _get_bboxes()

--- a/src/sds_data_model/constants.py
+++ b/src/sds_data_model/constants.py
@@ -1,7 +1,7 @@
 from itertools import product
 from typing import Tuple
 
-BNG = "OSGB36 / British National Grid"
+BNG = "OSGB 1936 / British National Grid"
 BNG_XMIN = 0
 BNG_YMIN = 0
 BNG_XMAX = 700_000
@@ -20,6 +20,7 @@ CHARACTER_STRING = GCO + "CharacterString"
 
 BoundingBox = Tuple[int, int, int, int]
 
+raster_dtype_levels = ['int8', 'uint8', 'uint16', 'int16', 'uint32', 'int32', 'float32', 'float64']
 
 def _get_bboxes(
     xmin: int = BNG_XMIN,

--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -259,10 +259,12 @@ class TiledVectorLayer:
         self: _TiledVectorLayer,
         categorical_column: str,
     ) -> DataArray:
+        
+        tiles=[i for i in self.tiles]
 
         col_dtypes = (
             tile.get_col_dtype(categorical_column=categorical_column)
-            for tile in self.tiles
+            for tile in tiles
         )
 
         col_dtypes_clean = [x for x in list(col_dtypes) if x is not None]
@@ -271,8 +273,10 @@ class TiledVectorLayer:
 
         delayed_categorical_rasters = (
             tile.to_categorical_raster(categorical_column=categorical_column, dtype=dtype)
-            for tile in self.tiles
+            for tile in tiles
         )
+
+        # print(list(delayed_categorical_rasters))
 
         data_array = _from_delayed_to_data_array(
             delayed_arrays=delayed_categorical_rasters,

--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -323,8 +323,8 @@ class VectorLayer:
     ) -> _VectorLayer:
         gpdf = read_file(data_path, **data_kwargs)
 
-        if gpdf.crs.name != BNG:
-            raise TypeError(f"CRS must be {BNG}, not {gpdf.crs.name}")
+        if gpdf.crs.name not in BNG:
+            raise TypeError(f"CRS must be one of {BNG}, not {gpdf.crs.name}")
 
         # if not metadata_path:
         #     metadata = json.load(f"{data_path}-metadata.json")

--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -258,7 +258,7 @@ class TiledVectorLayer:
 
     def to_dataset_as_raster(
         self: _TiledVectorLayer,
-        columns: List[str, ...],
+        columns: List[str],
     ) -> Dataset:
         """This method instantiates the tiles so that they can be used in subsequent methods.
         get_col_dtypes is called on all vectortiles, removes None (due to tiles on irish sea), 

--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -148,7 +148,7 @@ _TiledVectorLayer = TypeVar("_TiledVectorLayer", bound="TiledVectorLayer")
 class TiledVectorLayer:
     name: str
     tiles: Generator[VectorTile, None, None]
-    metadata: Metadata
+    metadata: Optional[Metadata]
 
     @classmethod
     def from_files(
@@ -176,7 +176,7 @@ class TiledVectorLayer:
         #     raise TypeError(f"CRS must be {BNG}, not {gpdf.crs.name}")
 
         if not metadata_path:
-            metadata = ""
+            metadata = None
         else:
             metadata = Metadata.from_file(metadata_path)
 
@@ -311,7 +311,7 @@ _VectorLayer = TypeVar("_VectorLayer", bound="VectorLayer")
 class VectorLayer:
     name: str
     gpdf: GeoDataFrame
-    metadata: Metadata
+    metadata: Optional[Metadata]
 
     @classmethod
     def from_files(
@@ -326,17 +326,17 @@ class VectorLayer:
         if gpdf.crs.name not in BNG:
             raise TypeError(f"CRS must be one of {BNG}, not {gpdf.crs.name}")
 
-        # if not metadata_path:
-        #     metadata = json.load(f"{data_path}-metadata.json")
-        # else:
-        #     metadata = Metadata.from_file(metadata_path)
+        if not metadata_path:
+            metadata = None
+        else:
+            metadata = Metadata.from_file(metadata_path)
 
         _name = name if name else metadata["title"]
 
         return cls(
             name=_name,
             gpdf=gpdf,
-            metadata=''#metadata,
+            metadata=metadata,
         )
 
     def to_tiles(self, bboxes: Tuple[BoundingBox] = BBOXES) -> TiledVectorLayer:

--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -258,7 +258,7 @@ class TiledVectorLayer:
 
     def to_dataset_as_raster(
         self: _TiledVectorLayer,
-        columns: list[str, ...],
+        columns: List[str, ...],
     ) -> Dataset:
         """This method instantiates the tiles so that they can be used in subsequent methods.
         get_col_dtypes is called on all vectortiles, removes None (due to tiles on irish sea), 


### PR DESCRIPTION
This pr changes the function `to_data_array_as_categorical_raster` to `to_dataset_as_raster`.

The function will now:
- rasterise a column and assign the minimum possible datatype.
- allow a variable length list of column names to be passed and rasterise each one.

e.g. 

```python
from sds_data_model import vector

my_dataset = (
    vector.VectorLayer.from_files(
        data_path = "Local_Authority_Districts_(December_2021)_GB_BGC/LAD_DEC_2021_GB_BGC.shp",
        data_kwargs = {},
        name = "lad",    
    )
   .to_tiles()
   .to_dataset_as_raster(
        columns = ["OBJECTID", "BNG_E", "SHAPE_Area"]
    )
)

```

Returns an `xarray.Dataset` consisting of three `xarray.DataArray`'s, using types `uint16`, `uint32` & `float64`.