### PR TITLE
fix min dtype for floats/issue44

### DIFF
--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -133,11 +133,16 @@ class VectorTile:
         self: _VectorTile,
         column: str,
     ) -> str:
-        """This method calls _get_col_dtype on an individual vectortile."""
-        return _get_col_dtype(
-            gpdf=self.gpdf,
-            column=column,
-        )
+        """This method calls _get_col_dtype on an individual vectortile,
+        if the geodataframe of the vector tile contains data."""
+        gpdf = self.gpdf
+        if not gpdf.empty:
+            return _get_col_dtype(
+                gpdf=gpdf,
+                column=column,
+            )
+        else:
+            return None
 
 
 

--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -132,7 +132,7 @@ class VectorTile:
     def get_col_dtype(
         self: _VectorTile,
         column: str,
-    ) -> str:
+    ) -> Optional[str]:
         """This method calls _get_col_dtype on an individual vectortile,
         if the geodataframe of the vector tile contains data."""
         gpdf = self.gpdf


### PR DESCRIPTION
This pull request modifys the function `get_col_dtype`.
Instead of directly passing the GeoDataFrame of the VectorTile to the `_get_col_dtype` function it first checks if the GeoDataFrame is empty. 
- If it is not empty the GeoDataFrame will be passed to `_get_col_dtype`. 
- If it is empty the function will return `None`.