### PR TITLE
add schema/dtype attribute - JK/issue40

### DIFF
--- a/src/sds_data_model/_vector.py
+++ b/src/sds_data_model/_vector.py
@@ -10,6 +10,7 @@ from geopandas import GeoDataFrame, read_file
 from more_itertools import chunked
 from numpy import arange, ones, zeros
 from pandas import DataFrame, Series, merge
+from pyogrio.core import ogr_read_info
 from rasterio.features import geometry_mask, rasterize
 from rasterio.dtypes import get_minimum_dtype
 from shapely.geometry import box
@@ -172,3 +173,19 @@ def _from_delayed_to_data_array(
         name=name,
         attrs=_metadata,
     )
+
+
+def _get_schema(
+    data_path: str,
+    **kwargs,
+) -> Dict[str, str]:
+    """Uses pyogrio.core.ogr_read_info to read file fields and dtypes and return as dict"""
+    return {
+        fields: dtypes 
+        for fields, dtypes in zip(
+            *map(
+                ogr_read_info(data_path, **kwargs).get, ["fields", "dtypes"]
+            )
+        )
+    }
+    


### PR DESCRIPTION
- Addresses second point in #40: "We want to get the data type of each field (without having to loop through the entire collection of tiles) so that we can use it when we rasterise a field" 
- Uses `pyogrio.core.ogr_read_info` to retrieve types from files. @EFT-Defra using this function instead of `pyogrio.read_info` allows kwargs to be easily passed mitigating the need to write a general function to return a layer name (instead of `ogr.Layer`).
- The pyogrio function is wrapped in an internal function in `_vector.py` called `_get_schema` that returns a dictionary of keys that the field names and values that are the `str` numpy type. This function is imported in vector.py and used to return an attribute `schema` for `VectorLayer` and `TiledVectorLayer`.
