### PR TITLE
Allow custom schema dict in VectorLayer

### DIFF
--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -304,6 +304,7 @@ class VectorLayer:
         convert_to_categorical: List[str] = None,
         metadata_path: Optional[str] = None,
         name: Optional[str] = None,
+        schema: Optional[Dict[str, Any]] = None
     ) -> _VectorLayer:
         info = _get_info(
             data_path=data_path,
@@ -312,7 +313,10 @@ class VectorLayer:
 
         _check_layer_projection(info)
 
-        schema = _get_schema(info)
+        if schema is not None:
+            schema = schema
+        else:
+            schema = _get_schema(info)
 
         if not metadata_path:
             metadata = None

--- a/src/sds_data_model/vector.py
+++ b/src/sds_data_model/vector.py
@@ -306,6 +306,44 @@ class VectorLayer:
         name: Optional[str] = None,
         schema: Optional[Dict[str, Any]] = None
     ) -> _VectorLayer:
+
+        """Get a GeoDataframe with accompanying information on name, metadata and schema.
+
+        Examples:
+            >>> from vector import VectorLayer
+            >>> aw = read_file("https://services.arcgis.com/JJzESW51TqeY9uat/arcgis/rest/services/Ancient_Woodland_England/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson").to_crs("epsg:27700")
+            >>> aw.to_file("aw.gpkg", layer='aw', driver="GPKG")
+            >>> aw_dict = {
+                'OBJECTID': 'int32',
+                'NAME': 'object',
+                'THEME': 'object',
+                'THEMNAME': 'object',
+                'THEMID': 'int64',
+                'STATUS': 'object',
+                'PERIMETER': 'float64',
+                'AREA': 'float64',
+                'X_COORD': 'int64',
+                'Y_COORD': 'int64',
+                'Shape__Area': 'float64',
+                'Shape__Length': 'float64'
+                }
+            >>> VectorLayer.from_files(
+                data_path = "aw.gpkg",
+                name = "Ancient Woodland - test dataset",
+                schema = aw_dict)
+        
+        Args:
+            data_path (str): file path to dataset.
+            data_kwargs (Optional[Dict[str, Any]]): 
+            convert_to_categorical (List[str]): 
+            metadata_path (Optional[str]): 
+            name (Optional[str]): optional name to give VectorLayer output.
+            schema (Optional[Dict[str, Any]]): optional dictionary of user-defined schema to pass, will get schema from dataset if none provided. User-defined dictionary should have the column as the "key", and the data type as the "value". 
+        
+        Returns:
+            VectorLayer class of dataset. 
+    """
+
         info = _get_info(
             data_path=data_path,
             data_kwargs=data_kwargs,


### PR DESCRIPTION
This pull request closes #60 

We wanted to add an optional parameter to the `from_files` method of `VectorLayer` or `TiledVectorLayer` that takes a dictionary in the same format as the one returned by the `_get_schema` method. If such a dictionary is passed to the method, it will be used instead of calling the `_get_schema` function. 

The following should hopefully work for most. 

Save an example dataset to a `geopackage`.
```python
aw = read_file("https://services.arcgis.com/JJzESW51TqeY9uat/arcgis/rest/services/Ancient_Woodland_England/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson").to_crs("epsg:27700")

aw.to_file("aw.gpkg", layer='aw', driver="GPKG")
```

Get the schema of said dataset.
```python
from _vector import _get_schema, _get_info

_get_schema(_get_info(data_path="aw.gpkg"))
```
Which returns the following:
`
{'OBJECTID': 'int64',
 'NAME': 'object',
 'THEME': 'object',
 'THEMNAME': 'object',
 'THEMID': 'int64',
 'STATUS': 'object',
 'PERIMETER': 'float64',
 'AREA': 'float64',
 'X_COORD': 'int64',
 'Y_COORD': 'int64',
 'Shape__Area': 'float64',
 'Shape__Length': 'float64'}
`

You can pass a custom dictionary directly to the `from_files` method.
```python
from vector import VectorLayer

aw_dict = {'OBJECTID': 'int32',
 'NAME': 'object',
 'THEME': 'object',
 'THEMNAME': 'object',
 'THEMID': 'int64',
 'STATUS': 'object',
 'PERIMETER': 'float64',
 'AREA': 'float64',
 'X_COORD': 'int64',
 'Y_COORD': 'int64',
 'Shape__Area': 'float64',
 'Shape__Length': 'float64'}

VectorLayer.from_files(
    data_path = "aw.gpkg",
    name = "Ancient Woodland - test dataset",
    schema = aw_dict)
```

You can also create the `VectorLayer` class directly. 
```python
expected = VectorLayer(
    gpdf = aw,
    schema = aw_dict
)
```

Just to flag that we haven't managed to sort the `pytest` as of yet. 