### PR TITLE
Resolve `numpy` version conflict

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1710,6 +1710,22 @@ packaging = "*"
 requests = "*"
 
 [[package]]
+name = "scipy"
+version = "1.9.2"
+description = "Fundamental algorithms for scientific computing in Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+numpy = ">=1.18.5,<1.26.0"
+
+[package.extras]
+test = ["pytest", "pytest-cov", "pytest-xdist", "asv", "mpmath", "gmpy2", "threadpoolctl", "scikit-umfpack"]
+doc = ["sphinx (!=4.1.0)", "pydata-sphinx-theme (==0.9.0)", "sphinx-panels (>=0.5.2)", "matplotlib (>2)", "numpydoc", "sphinx-tabs"]
+dev = ["mypy", "typing-extensions", "pycodestyle", "flake8"]
+
+[[package]]
 name = "setuptools-scm"
 version = "7.0.5"
 description = "the blessed package to manage your versions by scm tags"
@@ -2146,7 +2162,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.8"
-content-hash = "92bde24e1ac619a7f26b0a54ec56dcdd6cc7419429c94e71b028b2908259c678"
+content-hash = "94ea2a47cde0c4c8b70d47ebd3fad271f4a805a0edfbf8a349f432881bd11676"
 
 [metadata.files]
 affine = []
@@ -2285,6 +2301,7 @@ rtree = []
 "ruamel.yaml" = []
 "ruamel.yaml.clib" = []
 safety = []
+scipy = []
 setuptools-scm = []
 shapely = []
 six = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -2157,7 +2157,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.8"
-content-hash = "3fe13b5e6188eb4a681881f0306523a86b5e76e53dd44a52d135e5eaf6ea5676"
+content-hash = "00fef696d869b7f3afc94df0e4abb3856e0f70449b2b82a6f9608d01d5842e2f"
 
 [metadata.files]
 affine = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -1710,17 +1710,6 @@ packaging = "*"
 requests = "*"
 
 [[package]]
-name = "scipy"
-version = "1.9.1"
-description = "SciPy: Scientific Library for Python"
-category = "main"
-optional = false
-python-versions = ">=3.8,<3.12"
-
-[package.dependencies]
-numpy = ">=1.18.5,<1.25.0"
-
-[[package]]
 name = "setuptools-scm"
 version = "7.0.5"
 description = "the blessed package to manage your versions by scm tags"
@@ -2157,7 +2146,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.8"
-content-hash = "00fef696d869b7f3afc94df0e4abb3856e0f70449b2b82a6f9608d01d5842e2f"
+content-hash = "92bde24e1ac619a7f26b0a54ec56dcdd6cc7419429c94e71b028b2908259c678"
 
 [metadata.files]
 affine = []
@@ -2296,7 +2285,6 @@ rtree = []
 "ruamel.yaml" = []
 "ruamel.yaml.clib" = []
 safety = []
-scipy = []
 setuptools-scm = []
 shapely = []
 six = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -10,66 +10,6 @@ python-versions = "*"
 test = ["pytest (>=4.6)", "pytest-cov", "pydocstyle", "flake8", "coveralls"]
 
 [[package]]
-name = "aiobotocore"
-version = "2.4.0"
-description = "Async client for aws services using botocore and aiohttp"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-aiohttp = ">=3.3.1"
-aioitertools = ">=0.5.1"
-botocore = ">=1.27.59,<1.27.60"
-wrapt = ">=1.10.10"
-
-[package.extras]
-awscli = ["awscli (>=1.25.60,<1.25.61)"]
-boto3 = ["boto3 (>=1.24.59,<1.24.60)"]
-
-[[package]]
-name = "aiohttp"
-version = "3.8.3"
-description = "Async http client/server framework (asyncio)"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-aiosignal = ">=1.1.2"
-async-timeout = ">=4.0.0a3,<5.0"
-attrs = ">=17.3.0"
-charset-normalizer = ">=2.0,<3.0"
-frozenlist = ">=1.1.1"
-multidict = ">=4.5,<7.0"
-yarl = ">=1.0,<2.0"
-
-[package.extras]
-speedups = ["aiodns", "brotli", "cchardet"]
-
-[[package]]
-name = "aioitertools"
-version = "0.11.0"
-description = "itertools and builtins for AsyncIO and mixed iterables"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing_extensions = {version = ">=4.0", markers = "python_version < \"3.10\""}
-
-[[package]]
-name = "aiosignal"
-version = "1.2.0"
-description = "aiosignal: a list of registered asynchronous callbacks"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-frozenlist = ">=1.1.0"
-
-[[package]]
 name = "alabaster"
 version = "0.7.12"
 description = "A configurable sidebar-enabled Sphinx theme"
@@ -128,14 +68,6 @@ six = "*"
 
 [package.extras]
 test = ["astroid (<=2.5.3)", "pytest"]
-
-[[package]]
-name = "async-timeout"
-version = "4.0.2"
-description = "Timeout context manager for asyncio programs"
-category = "main"
-optional = false
-python-versions = ">=3.6"
 
 [[package]]
 name = "atomicwrites"
@@ -235,22 +167,6 @@ pillow = ">=7.1.0"
 PyYAML = ">=3.10"
 tornado = ">=5.1"
 typing-extensions = ">=3.10.0"
-
-[[package]]
-name = "botocore"
-version = "1.27.59"
-description = "Low-level, data-driven core of boto 3."
-category = "main"
-optional = false
-python-versions = ">= 3.7"
-
-[package.dependencies]
-jmespath = ">=0.7.1,<2.0.0"
-python-dateutil = ">=2.1,<3.0.0"
-urllib3 = ">=1.25.4,<1.27"
-
-[package.extras]
-crt = ["awscrt (==0.14.0)"]
 
 [[package]]
 name = "cached-property"
@@ -684,14 +600,6 @@ unicode = ["unicodedata2 (>=14.0.0)"]
 woff = ["zopfli (>=0.1.4)", "brotlicffi (>=0.8.0)", "brotli (>=1.0.1)"]
 
 [[package]]
-name = "frozenlist"
-version = "1.3.1"
-description = "A list-like structure which implements collections.abc.MutableSequence"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
 name = "fsspec"
 version = "2022.8.2"
 description = "File-system specification"
@@ -925,14 +833,6 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
-name = "jmespath"
-version = "1.0.1"
-description = "JSON Matching Expressions"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[[package]]
 name = "jupyter-client"
 version = "7.3.5"
 description = "Jupyter protocol implementation and client libraries"
@@ -1109,14 +1009,6 @@ description = "More routines for operating on iterables, beyond itertools"
 category = "main"
 optional = false
 python-versions = ">=3.5"
-
-[[package]]
-name = "multidict"
-version = "6.0.2"
-description = "multidict implementation"
-category = "main"
-optional = false
-python-versions = ">=3.7"
 
 [[package]]
 name = "munch"
@@ -1804,23 +1696,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "s3fs"
-version = "2022.8.2"
-description = "Convenient Filesystem interface over S3"
-category = "main"
-optional = false
-python-versions = ">= 3.7"
-
-[package.dependencies]
-aiobotocore = ">=2.4.0,<2.5.0"
-aiohttp = "<4.0.0a0 || >4.0.0a0,<4.0.0a1 || >4.0.0a1"
-fsspec = "2022.8.2"
-
-[package.extras]
-awscli = ["aiobotocore[awscli] (>=2.4.0,<2.5.0)"]
-boto3 = ["aiobotocore[boto3] (>=2.4.0,<2.5.0)"]
-
-[[package]]
 name = "safety"
 version = "1.10.3"
 description = "Checks installed dependencies for known vulnerabilities."
@@ -2197,14 +2072,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "wrapt"
-version = "1.14.1"
-description = "Module for decorators, wrappers and monkey patching."
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
-[[package]]
 name = "xarray"
 version = "2022.9.0"
 description = "N-D labeled arrays and datasets in Python"
@@ -2259,18 +2126,6 @@ docs = ["sphinx"]
 build = ["twine", "wheel"]
 
 [[package]]
-name = "yarl"
-version = "1.8.1"
-description = "Yet another URL library"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-idna = ">=2.0"
-multidict = ">=4.0"
-
-[[package]]
 name = "zarr"
 version = "2.13.2"
 description = "An implementation of chunked, compressed, N-dimensional arrays for Python."
@@ -2302,21 +2157,16 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.8"
-content-hash = "7e0c57afd5167bb7c90d386982532b2821fd46eb67888962877e9ad4f3eb7495"
+content-hash = "3fe13b5e6188eb4a681881f0306523a86b5e76e53dd44a52d135e5eaf6ea5676"
 
 [metadata.files]
 affine = []
-aiobotocore = []
-aiohttp = []
-aioitertools = []
-aiosignal = []
 alabaster = []
 appnope = []
 argcomplete = []
 asciitree = []
 "aspy.refactor-imports" = []
 asttokens = []
-async-timeout = []
 atomicwrites = []
 attrs = []
 babel = []
@@ -2324,7 +2174,6 @@ backcall = []
 bandit = []
 black = []
 bokeh = []
-botocore = []
 cached-property = []
 certifi = []
 cffi = []
@@ -2361,7 +2210,6 @@ flake8-polyfill = []
 flake8-pyproject = []
 flake8-rst-docstrings = []
 fonttools = []
-frozenlist = []
 fsspec = []
 geopandas = []
 gitdb = []
@@ -2377,7 +2225,6 @@ ipython = []
 isort = []
 jedi = []
 jinja2 = []
-jmespath = []
 jupyter-client = []
 jupyter-core = []
 kiwisolver = []
@@ -2392,7 +2239,6 @@ mccabe = []
 mdit-py-plugins = []
 mdurl = []
 more-itertools = []
-multidict = []
 munch = []
 mypy = []
 mypy-extensions = []
@@ -2449,7 +2295,6 @@ rioxarray = []
 rtree = []
 "ruamel.yaml" = []
 "ruamel.yaml.clib" = []
-s3fs = []
 safety = []
 scipy = []
 setuptools-scm = []
@@ -2482,10 +2327,8 @@ typing-extensions = []
 urllib3 = []
 virtualenv = []
 wcwidth = []
-wrapt = []
 xarray = []
 xdoctest = []
 xlrd = []
-yarl = []
 zarr = []
 zipp = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -784,11 +784,11 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.4"
+version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "imagesize"
@@ -1835,6 +1835,17 @@ packaging = "*"
 requests = "*"
 
 [[package]]
+name = "scipy"
+version = "1.9.1"
+description = "SciPy: Scientific Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8,<3.12"
+
+[package.dependencies]
+numpy = ">=1.18.5,<1.25.0"
+
+[[package]]
 name = "setuptools-scm"
 version = "7.0.5"
 description = "the blessed package to manage your versions by scm tags"
@@ -2291,7 +2302,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.8"
-content-hash = "de471339ad5cb4df875426ebaa5bf4e204a12a546880a61def7789c0b67e3802"
+content-hash = "7e0c57afd5167bb7c90d386982532b2821fd46eb67888962877e9ad4f3eb7495"
 
 [metadata.files]
 affine = []
@@ -2440,6 +2451,7 @@ rtree = []
 "ruamel.yaml.clib" = []
 s3fs = []
 safety = []
+scipy = []
 setuptools-scm = []
 shapely = []
 six = []

--- a/poetry.lock
+++ b/poetry.lock
@@ -199,11 +199,11 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "black"
-version = "22.8.0"
+version = "22.10.0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
-python-versions = ">=3.6.2"
+python-versions = ">=3.7"
 
 [package.dependencies]
 click = ">=8.0.0"
@@ -749,7 +749,7 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.27"
+version = "3.1.28"
 description = "GitPython is a python library used to interact with Git repositories"
 category = "dev"
 optional = false
@@ -1557,7 +1557,7 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pyogrio"
-version = "0.4.1"
+version = "0.4.2"
 description = "Vectorized spatial vector file format I/O using GDAL/OGR"
 category = "main"
 optional = false
@@ -2122,7 +2122,7 @@ test = ["pytest", "typing-extensions", "mypy"]
 
 [[package]]
 name = "types-requests"
-version = "2.28.11.1"
+version = "2.28.11.2"
 description = "Typing stubs for requests"
 category = "main"
 optional = false
@@ -2141,7 +2141,7 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "4.3.0"
+version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
@@ -2291,7 +2291,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "~3.8"
-content-hash = "0f12a4c3c81030fb51f597505ea6596baa49a2d9c9765514f33b1a9c838d8ab5"
+content-hash = "de471339ad5cb4df875426ebaa5bf4e204a12a546880a61def7789c0b67e3802"
 
 [metadata.files]
 affine = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ graphviz = "^0.20.1"
 opencv-python = "^4.6.0"
 rioxarray = "^0.12.0"
 types-requests = "^2.28.9"
-numpy = "^1.23.3"
 scipy = "^1.9.1"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ graphviz = "^0.20.1"
 opencv-python = "^4.6.0"
 rioxarray = "^0.12.0"
 types-requests = "^2.28.9"
-scipy = "^1.9.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ zarr = "^2.11.1"
 netCDF4 = "^1.5.8"
 dask = {extras = ["diagnostics"], version = "2022.4.0"}
 Rtree = "^0.9.7"
-s3fs = "^2022.3.0"
 more-itertools = "^8.12.0"
 lxml = "^4.9.1"
 xlrd = "^2.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ Changelog = "https://github.com/Defra-Data-Science-Centre-of-Excellence/sds-data
 [tool.poetry.dependencies]
 python = "~3.8"
 geopandas = "^0.10.2"
-requests = "^2.27.1"
-matplotlib = "^3.5.1"
+requests = "^2.28.1"
+matplotlib = "^3.6.0"
 rasterio = "^1.2.10"
 xarray = "^2022.3.0"
 zarr = "^2.11.1"
@@ -38,6 +38,7 @@ opencv-python = "^4.6.0"
 rioxarray = "^0.12.0"
 types-requests = "^2.28.9"
 numpy = "^1.23.3"
+scipy = "^1.9.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ graphviz = "^0.20.1"
 opencv-python = "^4.6.0"
 rioxarray = "^0.12.0"
 types-requests = "^2.28.9"
+scipy = "^1.9.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ graphviz = "^0.20.1"
 opencv-python = "^4.6.0"
 rioxarray = "^0.12.0"
 types-requests = "^2.28.9"
+numpy = "^1.23.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
The issue is `scipy`. [Databrick Runtime 10.4 LTS](https://docs.databricks.com/release-notes/runtime/10.4.html#installed-python-libraries) has `1.6.2` and `numpy` `1.20.1`. `numpy` is constrained by `scipy` so just upgrading `numpy` doesn't fix the problem but explicitly depending on the latest version of `scipy` does, so that's what I've done. 