### PR TITLE
Jpd defra/issue189

### DIFF
--- a/src/sds_data_model/__init__.py
+++ b/src/sds_data_model/__init__.py
@@ -310,6 +310,16 @@ been changed from the defaults:
         geometry_column_name="custom_geometry",
     )
 
+In line with the `xarray.Dataset.to_zarr` method, `to_zarr` will accept both a
+path to a directory and a path to a directory suffixed with .zarr.
+
+Overwriting
+^^^^^^^^^^^
+
+The `to_zarr` method has a default overwrite flag set to False. This means that
+if a zarr dataset exists in the path provided to the method, then an error will
+be thrown. The flag can be set by the user to True to allow overwriting.
+
 
 A full workflow
 ---------------

--- a/src/sds_data_model/_dataframe.py
+++ b/src/sds_data_model/_dataframe.py
@@ -343,7 +343,7 @@ def _create_dummy_dataset(
     )
 
 
-def _check_for_zarr(path: str) -> bool:
+def _check_for_zarr(path: Path) -> bool:
     """Check if a zarr file exists in a given location.
 
     Args:
@@ -352,9 +352,8 @@ def _check_for_zarr(path: str) -> bool:
     Returns:
         bool: Whether the zarr exists.
     """
-    _path = Path(path)
     try:
-        open_dataset(_path, engine="zarr")
+        open_dataset(path, engine="zarr")
         return True
     except FileNotFoundError:
         return False

--- a/src/sds_data_model/_dataframe.py
+++ b/src/sds_data_model/_dataframe.py
@@ -14,7 +14,6 @@ from pyspark.sql.types import ArrayType, FloatType
 from rasterio.features import geometry_mask
 from shapely.wkt import loads
 from xarray import DataArray, open_dataset
-from xarray.core.dataset import Dataset
 
 from sds_data_model.constants import (
     BNG_XMAX,
@@ -345,17 +344,17 @@ def _create_dummy_dataset(
 
 
 def _check_for_zarr(path: str) -> bool:
-    """Check if a Zarr file exists in a given location.
+    """Check if a zarr file exists in a given location.
 
     Args:
-        path (str): Directory to check for Zarr files.
+        path (str): Directory to check for zarr file(s).
 
     Returns:
-        bool: Whether the Zarr exists.
+        bool: Whether the zarr exists.
     """
     _path = Path(path)
     try:
-        open_dataset(_path, engine = 'zarr')
+        open_dataset(_path, engine="zarr")
         return True
-    except ValueError:
+    except FileNotFoundError:
         return False

--- a/src/sds_data_model/_dataframe.py
+++ b/src/sds_data_model/_dataframe.py
@@ -347,7 +347,7 @@ def _check_for_zarr(path: Path) -> bool:
     """Check if a zarr file exists in a given location.
 
     Args:
-        path (str): Directory to check for zarr file(s).
+        path (Path): Directory to check for zarr file(s).
 
     Returns:
         bool: Whether the zarr exists.

--- a/src/sds_data_model/_dataframe.py
+++ b/src/sds_data_model/_dataframe.py
@@ -276,6 +276,7 @@ def _create_dummy_dataset(
     bng_xmax: int = BNG_XMAX,
     bng_ymin: int = BNG_YMIN,
     bng_ymax: int = BNG_YMAX,
+    overwrite: bool = False,
 ) -> None:
     """A dummy Dataset. It's metadata is used to create the initial `zarr` store.
 
@@ -309,6 +310,11 @@ def _create_dummy_dataset(
     .. _`Appending to existing Zarr stores`:
         https://docs.xarray.dev/en/stable/user-guide/io.html#appending-to-existing-zarr-stores  # noqa: B950
     """
+    
+    if not overwrite:
+        write_mode="w-"
+    write_mode="w"
+    
     _metadata = asdict(metadata) if metadata else None
 
     (
@@ -337,7 +343,7 @@ def _create_dummy_dataset(
         .to_dataset(promote_attrs=True)
         .to_zarr(
             store=path,
-            mode="w",
+            mode=write_mode,
             compute=False,
         )
     )

--- a/src/sds_data_model/_dataframe.py
+++ b/src/sds_data_model/_dataframe.py
@@ -13,7 +13,7 @@ from pyspark.sql.functions import udf
 from pyspark.sql.types import ArrayType, FloatType
 from rasterio.features import geometry_mask
 from shapely.wkt import loads
-from xarray import DataArray, open_zarr
+from xarray import DataArray, open_dataset
 from xarray.core.dataset import Dataset
 
 from sds_data_model.constants import (
@@ -353,10 +353,9 @@ def _check_for_zarr(path: str) -> bool:
     Returns:
         bool: Whether the Zarr exists.
     """
-    p = Path(path)
+    _path = Path(path)
     try:
-        z = open_zarr(p)
-        if isinstance(z, Dataset):
-            return True
+        open_dataset(_path, engine = 'zarr')
+        return True
     except ValueError:
         return False

--- a/src/sds_data_model/_dataframe.py
+++ b/src/sds_data_model/_dataframe.py
@@ -354,11 +354,9 @@ def _check_for_zarr(path: str) -> bool:
         bool: Whether the Zarr exists.
     """
     p = Path(path)
-    if p.exists():
-        try:
-            z = open_zarr(p)
-            if isinstance(z, Dataset):
-                return True
-        except ValueError:
-            return False
-    return False
+    try:
+        z = open_zarr(p)
+        if isinstance(z, Dataset):
+            return True
+    except ValueError:
+        return False

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -267,6 +267,9 @@ class DataFrameWrapper:
         
         path = Path(path)
         
+        if path.suffix == '.zarr':
+            path = path.with_suffix("")
+        
         if path.exists():
             
             if overwrite is False and _check_for_zarr(path):

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -224,6 +224,7 @@ class DataFrameWrapper:
         data_array_name: str,
         index_column_name: str = "bng_index",
         geometry_column_name: str = "geometry",
+        overwrite: bool = False,
     ) -> None:
         """Rasterises `self.data` and writes it to `zarr`.
 
@@ -265,6 +266,7 @@ class DataFrameWrapper:
             path=path,
             data_array_name=data_array_name,
             metadata=self.metadata,
+            overwrite=overwrite,
         )
 
         _partial_to_zarr_region = partial(

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -267,7 +267,6 @@ class DataFrameWrapper:
 
         _path = Path(path)
 
-
         if _path.exists():
 
             if overwrite is False and _check_for_zarr(_path):

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -267,7 +267,7 @@ class DataFrameWrapper:
 
         _path = Path(path)
 
-        #if _path.suffix == ".zarr":
+        # if _path.suffix == ".zarr":
         #    _path = _path.with_suffix("")
 
         if _path.exists():

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -268,7 +268,7 @@ class DataFrameWrapper:
         path = Path(path)
         
         if not path.is_dir():
-            raise ValueError("{path} is not a directory.")
+            raise ValueError(f"{path} is not a directory.")
         
         if path.exists():
             

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -267,8 +267,8 @@ class DataFrameWrapper:
 
         _path = Path(path)
 
-        if _path.suffix == ".zarr":
-            _path = _path.with_suffix("")
+        #if _path.suffix == ".zarr":
+        #    _path = _path.with_suffix("")
 
         if _path.exists():
 

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -264,20 +264,20 @@ class DataFrameWrapper:
 
         if geometry_column_name not in colnames:
             raise ValueError(f"{geometry_column_name} is not present in the data.")
-        
+
         path = Path(path)
-        
-        if path.suffix == '.zarr':
+
+        if path.suffix == ".zarr":
             path = path.with_suffix("")
-        
+
         if path.exists():
-            
+
             if overwrite is False and _check_for_zarr(path):
                 raise ValueError(f"Zarr file already exists in {path}.")
-                
+
             if overwrite is True and _check_for_zarr(path):
                 print("Overwriting existing Zarr.")
-                
+
         _create_dummy_dataset(
             path=path,
             data_array_name=data_array_name,

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -267,9 +267,6 @@ class DataFrameWrapper:
         
         path = Path(path)
         
-        if not path.is_dir():
-            raise ValueError(f"{path} is not a directory.")
-        
         if path.exists():
             
             if overwrite is False and _check_for_zarr(path):

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -17,8 +17,6 @@ from pyspark.sql.types import ArrayType, StringType
 from pyspark_vector_files import read_vector_files
 from pyspark_vector_files.gpkg import read_gpkg
 
-from os.path import exists
-
 from sds_data_model._dataframe import (
     _bng_to_bounds,
     _check_for_zarr,
@@ -267,7 +265,12 @@ class DataFrameWrapper:
         if geometry_column_name not in colnames:
             raise ValueError(f"{geometry_column_name} is not present in the data.")
         
-        if exists(path):
+        path = Path(path)
+        
+        if not path.is_dir():
+            raise ValueError("{path} is not a directory.")
+        
+        if path.exists():
             
             if overwrite is False and _check_for_zarr(path):
                 raise ValueError(f"Zarr file already exists in {path}.")

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -268,6 +268,9 @@ class DataFrameWrapper:
         if overwrite is False and _check_for_zarr(path):
             raise ValueError(f"Zarr file already exists in {path}.")
 
+        if overwrite is True and _check_for_zarr(path):
+            print("Overwriting existing Zarr.")
+
         _create_dummy_dataset(
             path=path,
             data_array_name=data_array_name,

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -267,8 +267,6 @@ class DataFrameWrapper:
 
         _path = Path(path)
 
-        # if _path.suffix == ".zarr":
-        #    _path = _path.with_suffix("")
 
         if _path.exists():
 

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from functools import partial
 from inspect import ismethod, signature
-from logging import INFO, Formatter, StreamHandler, getLogger
+from logging import INFO, Formatter, StreamHandler, getLogger, warning
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Sequence, Type, TypeVar, Union
 
@@ -265,18 +265,18 @@ class DataFrameWrapper:
         if geometry_column_name not in colnames:
             raise ValueError(f"{geometry_column_name} is not present in the data.")
 
-        path = Path(path)
+        _path = Path(path)
 
-        if path.suffix == ".zarr":
-            path = path.with_suffix("")
+        if _path.suffix == ".zarr":
+            _path = _path.with_suffix("")
 
-        if path.exists():
+        if _path.exists():
 
-            if overwrite is False and _check_for_zarr(path):
-                raise ValueError(f"Zarr file already exists in {path}.")
+            if overwrite is False and _check_for_zarr(_path):
+                raise ValueError(f"Zarr file already exists in {_path}.")
 
-            if overwrite is True and _check_for_zarr(path):
-                print("Overwriting existing Zarr.")
+            if overwrite is True and _check_for_zarr(_path):
+                warning("Overwriting existing zarr.")
 
         _create_dummy_dataset(
             path=path,

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -19,6 +19,7 @@ from pyspark_vector_files.gpkg import read_gpkg
 
 from sds_data_model._dataframe import (
     _bng_to_bounds,
+    _check_for_zarr,
     _create_dummy_dataset,
     _to_zarr_region,
 )
@@ -246,6 +247,7 @@ class DataFrameWrapper:
                 "bng_index".
             geometry_column_name (str): Name of the geometry column. Defaults to
                 "geometry".
+            overwrite (bool): Overwrite existing zarr? Defaults to False.
 
         Returns:
             None
@@ -253,6 +255,7 @@ class DataFrameWrapper:
         Raises:
             ValueError: If `index_column_name` isn't in the dataframe.
             ValueError: If `geometry_column_name` isn't in the dataframe.
+            ValueError: If Zarr file exists and overwrite set to False.
         """
         colnames = self.data.columns
 
@@ -262,11 +265,13 @@ class DataFrameWrapper:
         if geometry_column_name not in colnames:
             raise ValueError(f"{geometry_column_name} is not present in the data.")
 
+        if overwrite is False and _check_for_zarr(path):
+            raise ValueError(f"Zarr file already exists in {path}.")
+
         _create_dummy_dataset(
             path=path,
             data_array_name=data_array_name,
             metadata=self.metadata,
-            overwrite=overwrite,
         )
 
         _partial_to_zarr_region = partial(

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -17,6 +17,8 @@ from pyspark.sql.types import ArrayType, StringType
 from pyspark_vector_files import read_vector_files
 from pyspark_vector_files.gpkg import read_gpkg
 
+from os.path import exists
+
 from sds_data_model._dataframe import (
     _bng_to_bounds,
     _check_for_zarr,
@@ -264,13 +266,15 @@ class DataFrameWrapper:
 
         if geometry_column_name not in colnames:
             raise ValueError(f"{geometry_column_name} is not present in the data.")
-
-        if overwrite is False and _check_for_zarr(path):
-            raise ValueError(f"Zarr file already exists in {path}.")
-
-        if overwrite is True and _check_for_zarr(path):
-            print("Overwriting existing Zarr.")
-
+        
+        if exists(path):
+            
+            if overwrite is False and _check_for_zarr(path):
+                raise ValueError(f"Zarr file already exists in {path}.")
+                
+            if overwrite is True and _check_for_zarr(path):
+                print("Overwriting existing Zarr.")
+                
         _create_dummy_dataset(
             path=path,
             data_array_name=data_array_name,

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -1,5 +1,6 @@
 """Tests for DataFrame wrapper class."""
 
+from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Union
 
 import pytest
@@ -141,3 +142,19 @@ def test_to_zarr_with_metadata(
     )
 
     assert hl_dataset.attrs == expected_hl_dataset_with_metadata.attrs
+
+
+def test_zarr_overwrite_check(
+    hl_wrapper_no_metadata: DataFrameWrapper,
+    tmp_path: str,
+    # expected_exception: Any,
+) -> None:
+    """?."""
+    _path = Path(tmp_path)
+    with pytest.raises(ValueError, match=f"Zarr file already exists in {_path}."):
+        hl_wrapper_no_metadata.to_zarr(
+            path=str(tmp_path / "hl.zarr"), data_array_name="tmp_zarr"
+        )
+        hl_wrapper_no_metadata.to_zarr(
+            path=str(tmp_path / "hl.zarr"), data_array_name="tmp_zarr"
+        )

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -160,13 +160,15 @@ def test_zarr_overwrite_check(
     
     with pytest.raises(ValueError, match="Zarr file already exists"):
         
-        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+        hl_wrapper_no_metadata.to_zarr(path=tmp_path,
                                        data_array_name="tmp_zarr")
         
         print(tmp_path)
         print(os.listdir(tmp_path))
         
-        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl2.zarr"),
+        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl2.zarr"),
+        hl_wrapper_no_metadata.to_zarr(path=tmp_path,
                                        data_array_name="tmp_zarr")
         
         print(os.listdir(tmp_path))

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -152,10 +152,14 @@ def test_zarr_overwrite_check(
     """?."""
     _path = Path(tmp_path)
     
+    print(tmp_path)
+    
     with pytest.raises(ValueError, match="Zarr file already exists"):
         
         hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
                                        data_array_name="tmp_zarr")
+        
+        print(tmp_path)
         
         hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
                                        data_array_name="tmp_zarr")

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -157,7 +157,6 @@ def test_to_zarr_with_metadata(
         "out_zarr",
     ),
 )
-
 def test_zarr_overwrite_check(
     out_path: str,
     hl_wrapper_no_metadata: DataFrameWrapper,

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -147,8 +147,8 @@ def test_to_zarr_with_metadata(
 @pytest.mark.parametrize(
     argnames="out_path",
     argvalues=(
-        str(""),
-        str("hl.zarr"),
+        ("",),
+        ("hl.zarr",),
     ),
     ids=(
         "out_directory",

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -152,23 +152,13 @@ def test_zarr_overwrite_check(
     # expected_exception: Any,
 ) -> None:
     """?."""
-    _path = Path(tmp_path)
-    
-    print(tmp_path)
-    
-    print(os.listdir(tmp_path))
-    
+
     with pytest.raises(ValueError, match="Zarr file already exists"):
         
-        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
-        hl_wrapper_no_metadata.to_zarr(path=tmp_path,
+        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+        #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
                                        data_array_name="tmp_zarr")
         
-        print(tmp_path)
-        print(os.listdir(tmp_path))
-        
-        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl2.zarr"),
-        hl_wrapper_no_metadata.to_zarr(path=tmp_path,
+        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+        #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
                                        data_array_name="tmp_zarr")
-        
-        print(os.listdir(tmp_path))

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -1,5 +1,6 @@
 """Tests for DataFrame wrapper class."""
 
+from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Union
 
 import pytest
@@ -156,7 +157,7 @@ def test_to_zarr_with_metadata(
 )
 def test_zarr_overwrite_check(
     out_path: str,
-    tmp_path: str,
+    tmp_path: Path,
     hl_wrapper_no_metadata: DataFrameWrapper,
 ) -> None:
     """Check error thrown when a zarr output path already contains a zarr."""

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -151,10 +151,13 @@ def test_zarr_overwrite_check(
 ) -> None:
     """?."""
     _path = Path(tmp_path)
+
+    hl_wrapper_no_metadata.to_zarr(
+        path=str(tmp_path / "hl.zarr"), data_array_name="tmp_zarr"
+    )
+
     with pytest.raises(ValueError, match=f"Zarr file already exists in {_path}."):
-        hl_wrapper_no_metadata.to_zarr(
-            path=str(tmp_path / "hl.zarr"), data_array_name="tmp_zarr"
-        )
+
         hl_wrapper_no_metadata.to_zarr(
             path=str(tmp_path / "hl.zarr"), data_array_name="tmp_zarr"
         )

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -157,6 +157,7 @@ def test_to_zarr_with_metadata(
 )
 def test_zarr_overwrite_check(
     out_path: str,
+    tmp_path: str,
     hl_wrapper_no_metadata: DataFrameWrapper,
 ) -> None:
     """Check error thrown when a zarr output path already contains a zarr."""

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Union
 
+import os
+
 import pytest
 from chispa.dataframe_comparer import assert_df_equality
 from pyspark.sql import DataFrame as SparkDataFrame
@@ -154,12 +156,17 @@ def test_zarr_overwrite_check(
     
     print(tmp_path)
     
+    os.listdir(tmp_path)
+    
     with pytest.raises(ValueError, match="Zarr file already exists"):
         
         hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
                                        data_array_name="tmp_zarr")
         
         print(tmp_path)
+        os.listdir(tmp_path)
         
         hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
                                        data_array_name="tmp_zarr")
+        
+        os.listdir(tmp_path)

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -3,8 +3,6 @@
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Union
 
-import os
-
 import pytest
 from chispa.dataframe_comparer import assert_df_equality
 from pyspark.sql import DataFrame as SparkDataFrame
@@ -151,8 +149,8 @@ def test_to_zarr_with_metadata(
         "out_path",
     ),
     argvalues=(
-        (str(tmp_path)),
-        (str(tmp_path / 'hl.zarr')),
+        (str('')),
+        (str('hl.zarr')),
     ),
     ids=(
         "out_directory",
@@ -164,16 +162,16 @@ def test_zarr_overwrite_check(
     out_path: str,
     hl_wrapper_no_metadata: DataFrameWrapper,
 ) -> None:
-    """?."""
+    """Check error thrown when a zarr output path already contains a zarr."""
 
     with pytest.raises(ValueError, match="Zarr file already exists"):
         
         #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
         #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
-        hl_wrapper_no_metadata.to_zarr(out_path,
+        hl_wrapper_no_metadata.to_zarr(path = str(tmp_path / out_path),
                                        data_array_name="tmp_zarr")
         
         #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
         #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
-        hl_wrapper_no_metadata.to_zarr(out_path,
+        hl_wrapper_no_metadata.to_zarr(path = str(tmp_path / out_path),
                                        data_array_name="tmp_zarr")

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -166,7 +166,7 @@ def test_zarr_overwrite_check(
         print(tmp_path)
         print(os.listdir(tmp_path))
         
-        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl2.zarr"),
                                        data_array_name="tmp_zarr")
         
         print(os.listdir(tmp_path))

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -151,8 +151,8 @@ def test_to_zarr_with_metadata(
         ("hl.zarr",),
     ),
     ids=(
-        "out_directory",
-        "out_zarr",
+        "directory",
+        ".zarr file",
     ),
 )
 def test_zarr_overwrite_check(

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -156,7 +156,7 @@ def test_zarr_overwrite_check(
     
     print(tmp_path)
     
-    os.listdir(tmp_path)
+    print(os.listdir(tmp_path))
     
     with pytest.raises(ValueError, match="Zarr file already exists"):
         
@@ -164,9 +164,9 @@ def test_zarr_overwrite_check(
                                        data_array_name="tmp_zarr")
         
         print(tmp_path)
-        os.listdir(tmp_path)
+        print(os.listdir(tmp_path))
         
         hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
                                        data_array_name="tmp_zarr")
         
-        os.listdir(tmp_path)
+        print(os.listdir(tmp_path))

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -146,19 +146,34 @@ def test_to_zarr_with_metadata(
     assert hl_dataset.attrs == expected_hl_dataset_with_metadata.attrs
 
 
+@pytest.mark.parametrize(
+    argnames=(
+        "out_path",
+    ),
+    argvalues=(
+        (str(tmp_path)),
+        (str(tmp_path / 'hl.zarr')),
+    ),
+    ids=(
+        "out_directory",
+        "out_zarr",
+    ),
+)
+
 def test_zarr_overwrite_check(
+    out_path: str,
     hl_wrapper_no_metadata: DataFrameWrapper,
-    tmp_path: str,
-    # expected_exception: Any,
 ) -> None:
     """?."""
 
     with pytest.raises(ValueError, match="Zarr file already exists"):
         
-        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
         #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
+        hl_wrapper_no_metadata.to_zarr(out_path,
                                        data_array_name="tmp_zarr")
         
-        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
         #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
+        hl_wrapper_no_metadata.to_zarr(out_path,
                                        data_array_name="tmp_zarr")

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -145,12 +145,10 @@ def test_to_zarr_with_metadata(
 
 
 @pytest.mark.parametrize(
-    argnames=(
-        "out_path",
-    ),
+    argnames="out_path",
     argvalues=(
-        (str('')),
-        (str('hl.zarr')),
+        str(''),
+        str('hl.zarr'),
     ),
     ids=(
         "out_directory",

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -145,15 +145,17 @@ def test_to_zarr_with_metadata(
 
 
 @pytest.mark.parametrize(
-    argnames="out_path",
-    argvalues=(
+    argnames=[
+    "out_path",
+    ],
+    argvalues=[
         ("",),
         ("hl.zarr",),
-    ),
-    ids=(
+    ],
+    ids=[
         "directory",
         ".zarr file",
-    ),
+    ],
 )
 def test_zarr_overwrite_check(
     out_path: str,

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -152,7 +152,7 @@ def test_zarr_overwrite_check(
     """?."""
     _path = Path(tmp_path)
     
-    with pytest.raises(ValueError, match=f"Zarr file already exists in {_path}."):
+    with pytest.raises(ValueError, match="Zarr file already exists"):
         
         hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
                                        data_array_name="tmp_zarr")

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -151,13 +151,11 @@ def test_zarr_overwrite_check(
 ) -> None:
     """?."""
     _path = Path(tmp_path)
-
-    hl_wrapper_no_metadata.to_zarr(
-        path=str(tmp_path / "hl.zarr"), data_array_name="tmp_zarr"
-    )
-
+    
     with pytest.raises(ValueError, match=f"Zarr file already exists in {_path}."):
-
-        hl_wrapper_no_metadata.to_zarr(
-            path=str(tmp_path / "hl.zarr"), data_array_name="tmp_zarr"
-        )
+        
+        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+                                       data_array_name="tmp_zarr")
+        
+        hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
+                                       data_array_name="tmp_zarr")

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -146,7 +146,7 @@ def test_to_zarr_with_metadata(
 
 @pytest.mark.parametrize(
     argnames=[
-    "out_path",
+        "out_path",
     ],
     argvalues=[
         ("",),

--- a/tests/test_DataFrameWrapper.py
+++ b/tests/test_DataFrameWrapper.py
@@ -1,13 +1,12 @@
 """Tests for DataFrame wrapper class."""
 
-from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Union
 
 import pytest
 from chispa.dataframe_comparer import assert_df_equality
 from pyspark.sql import DataFrame as SparkDataFrame
 from pyspark.sql import SparkSession
-from pytest import FixtureRequest
+from pytest import FixtureRequest, raises
 from xarray import Dataset, open_dataset
 from xarray.testing import assert_identical
 
@@ -147,8 +146,8 @@ def test_to_zarr_with_metadata(
 @pytest.mark.parametrize(
     argnames="out_path",
     argvalues=(
-        str(''),
-        str('hl.zarr'),
+        str(""),
+        str("hl.zarr"),
     ),
     ids=(
         "out_directory",
@@ -161,15 +160,12 @@ def test_zarr_overwrite_check(
     hl_wrapper_no_metadata: DataFrameWrapper,
 ) -> None:
     """Check error thrown when a zarr output path already contains a zarr."""
+    with raises(ValueError, match="Zarr file already exists"):
 
-    with pytest.raises(ValueError, match="Zarr file already exists"):
-        
-        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
-        #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
-        hl_wrapper_no_metadata.to_zarr(path = str(tmp_path / out_path),
-                                       data_array_name="tmp_zarr")
-        
-        #hl_wrapper_no_metadata.to_zarr(path=str(tmp_path / "hl.zarr"),
-        #hl_wrapper_no_metadata.to_zarr(path=tmp_path,
-        hl_wrapper_no_metadata.to_zarr(path = str(tmp_path / out_path),
-                                       data_array_name="tmp_zarr")
+        hl_wrapper_no_metadata.to_zarr(
+            path=str(tmp_path / out_path), data_array_name="tmp_zarr"
+        )
+
+        hl_wrapper_no_metadata.to_zarr(
+            path=str(tmp_path / out_path), data_array_name="tmp_zarr"
+        )


### PR DESCRIPTION
Fixes #189.

- Introduces a new hidden function `_check_for_zarr`. This function takes a directory path and tries to read in a zarr from that directory. If successful, True is returned, and if not, False. 
- This was my first time using `try` and `except`, and I'm unsure if it's implemented correctly, despite behaviour being as expected.
-  `_check_for_zarr` forms part of some new code at the beginning of the `to_zarr` method. In combination with the value of the new `overwrite` flag (defaults to False), there are 3 outcomes:

1. If overwrite is False and a zarr is found an error is thrown.
2. If overwrite is True and a zarr is found, a message is provided and the function continues.
3. If overwrite is True/False and no zarr is found, the function continues.

After experimenting with the write modes of zarr, I decided it was better to deal with checking for existing zarrs before launching into the 'Spark' parts of the code, as this can take several minutes. Dealing with it beforehand, throws an immediate error (if appropriate). 

Documentation has also been updated, and if it's agreed this is the write approach, I will think about how to add a test for this. 