### PR TITLE
Use spark join to map dict on `DataFrameWrapper.data`

### DIFF
--- a/src/sds_data_model/_dataframe.py
+++ b/src/sds_data_model/_dataframe.py
@@ -1,6 +1,5 @@
 """Private functions for the DataFrame wrapper class."""
 from dataclasses import asdict
-from itertools import chain
 from json import load
 from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, List, Optional, Tuple, Union, cast
@@ -22,8 +21,8 @@ from numpy import (
 from numpy.typing import NDArray
 from pandas import DataFrame as PandasDataFrame
 from pyspark.sql import DataFrame as SparkDataFrame
-from pyspark.sql.column import Column
-from pyspark.sql.functions import col, create_map, lit
+from pyspark.sql import SparkSession
+from pyspark.sql.functions import col
 from pyspark.sql.functions import max as _max
 from pyspark.sql.functions import min as _min
 from pyspark.sql.functions import udf
@@ -274,6 +273,7 @@ def _map_dictionary_on_column(
     sdf: SparkDataFrame,
     column: str,
     lookup: Dict[Any, float],
+    spark: SparkSession,
 ) -> SparkDataFrame:
     """Map a lookup on a column of a `SparkDataFrame`.
 
@@ -281,18 +281,24 @@ def _map_dictionary_on_column(
         sdf (SparkDataFrame): Input DataFrame.
         column (str): Column to map lookup on.
         lookup (Dict[Any, float]): Input dictionary of `{original_value: new_value}`.
+        spark (SparkSession): spark session.
 
     Returns:
         SparkDataFrame: SparkDataFrame with updated column.
     """
-    _map = create_map(cast(Column, [lit(x) for x in chain(*lookup.items())]))
-    return sdf.withColumn(column, _map[col(column)])
+    _map = spark.createDataFrame(lookup.items(), schema=[column, "__value__"])
+    return (
+        sdf.join(_map, column, "left")
+        .withColumn(column, col("__value__"))
+        .drop("__value__")
+    )
 
 
 def _recode_column(
     sdf: SparkDataFrame,
     column: str,
     lookup: Union[Dict[str, Dict[Any, float]], Dict],
+    spark: SparkSession,
 ) -> Tuple[SparkDataFrame, Dict[Any, float]]:
     """Apply an auto-generated or input lookup to a columnn of a `SparkDataFrame`.
 
@@ -301,6 +307,7 @@ def _recode_column(
         column (str): Column to optionally generate lookup for and map lookup on.
         lookup (Union[Dict[str, Dict[Any, float]], Dict]): Optional input `dict` of
             `{column: {original_value: new_value}}`.
+        spark (SparkSession): spark session.
 
     Returns:
         Tuple[SparkDataFrame, Dict[Any, float]]: Updated SparkDataFrame, lookup
@@ -313,7 +320,7 @@ def _recode_column(
         _lookup = dict(
             zip(unique.rdd.flatMap(lambda x: x).collect(), range(unique.count()))
         )
-    return _map_dictionary_on_column(sdf, column, _lookup), _lookup
+    return _map_dictionary_on_column(sdf, column, _lookup, spark), _lookup
 
 
 def _get_minimum_column_dtype(

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -245,11 +245,11 @@ class DataFrameWrapper:
         spark: Optional[SparkSession] = None,
     ) -> _DataFrameWrapper:
         """Maps an auto-generated or given dictionary onto provided columns.
-        
+
         This method is used to create a lookup (stored within the DataFrameWrapper)
-        that is then used during the rasterisation process. 
-        
-        Note: do not use `categorize` more than once in a given session, as the 
+        that is then used during the rasterisation process.
+
+        Note: do not use `categorize` more than once in a given session, as the
         data from each run of the method update values inplace. If a new
         categorization is required then, re-create the DataFrameWrapper first.
 

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -245,6 +245,13 @@ class DataFrameWrapper:
         spark: Optional[SparkSession] = None,
     ) -> _DataFrameWrapper:
         """Maps an auto-generated or given dictionary onto provided columns.
+        
+        This method is used to create a lookup (stored within the DataFrameWrapper)
+        that is then used during the rasterisation process. 
+        
+        Note: do not use `categorize` more than once in a given session, as the 
+        data from each run of the method update values inplace. If a new
+        categorization is required then, re-create the DataFrameWrapper first.
 
         Args:
             columns (Sequence[str]): Columns to map on.

--- a/src/sds_data_model/dataframe.py
+++ b/src/sds_data_model/dataframe.py
@@ -15,6 +15,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 from bng_indexer import calculate_bng_index
@@ -241,6 +242,7 @@ class DataFrameWrapper:
         self: _DataFrameWrapper,
         columns: Sequence[str],
         lookup: Optional[Dict[str, Dict[Any, float]]] = None,
+        spark: Optional[SparkSession] = None,
     ) -> _DataFrameWrapper:
         """Maps an auto-generated or given dictionary onto provided columns.
 
@@ -248,17 +250,21 @@ class DataFrameWrapper:
             columns (Sequence[str]): Columns to map on.
             lookup (Optional[Dict[str, Dict[Any, float]]]): `{column: value-map}`
                 dictionary to map. Defaults to {}.
+            spark (Optional[SparkSession]): spark session.
 
         Returns:
             _DataFrameWrapper: SparkDataFrameWrapper
         """
+        _spark = spark if spark else SparkSession.getActiveSession()
         self.data = _check_sparkdataframe(self.data)
         if not self.lookup:
             self.lookup = {}
         if not lookup:
             lookup = {}
         for column in columns:
-            self.data, self.lookup[column] = _recode_column(self.data, column, lookup)
+            self.data, self.lookup[column] = _recode_column(
+                self.data, column, lookup, spark=cast(SparkSession, _spark)
+            )
         return self
 
     def to_zarr(


### PR DESCRIPTION
Addresses #205.

Converts lookup dictionary to spark dataframe which can be joined to `.data` and the values extracted.
~259x faster (than previous `create_map` usage) for 3_000_000 rows/unique categories.